### PR TITLE
Add Installation Instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@
 
 A minimalistic Python web framework for microcontrollers inspired by Flask
 
+## Installation
+
+Installation can be done directly from the microcontroller using the `upip` library.
+
+```
+>>> import upip
+>>> upip.install(["microdot", "microdot-asyncio"])
+```
+
+Or, it can be downloaded on the host machine, and transferred to the device.
+
+```
+# Download the dependencies to the `lib` directory
+micropython -m upip install -p lib microdot microdot-asyncio
+
+# Transfer the `lib` directory to the microcontroller
+ampy -p $PORT put lib
+```
+
 ## Documentation
 
 Coming soon!


### PR DESCRIPTION
Hello!

I don't know if you're looking for small contributions like this, but I am documenting things for myself as I test the framework, and I thought that it may be beneficial to others as well.

In this case, it simply explains how to install the framework. Either on the device itself, or from the host machine.

Thanks.