### PR TITLE
Handle Chrome preconnect, simplified run()

### DIFF
--- a/microdot-asyncio/microdot_asyncio.py
+++ b/microdot-asyncio/microdot_asyncio.py
@@ -114,18 +114,18 @@ class Microdot(BaseMicrodot):
                         if res:
                             break
                     if res is None:
-                        res = await self._invoke_handler(f, 
-                                req, **req.url_args)
+                        res = await self._invoke_handler(
+                            f, req, **req.url_args)
                     if isinstance(res, tuple):
                         res = Response(*res)
                     elif not isinstance(res, Response):
                         res = Response(res)
                     for handler in self.after_request_handlers:
                         res = await self._invoke_handler(handler, req, res) \
-                                or res
+                            or res
                 elif 404 in self.error_handlers:
-                    res = await self._invoke_handler(self.error_handlers[404], 
-                        req)
+                    res = await self._invoke_handler(
+                        self.error_handlers[404], req)
                 else:
                     res = 'Not found', 404
             except Exception as exc:

--- a/microdot-asyncio/microdot_asyncio.py
+++ b/microdot-asyncio/microdot_asyncio.py
@@ -114,15 +114,18 @@ class Microdot(BaseMicrodot):
                         if res:
                             break
                     if res is None:
-                        res = await self._invoke_handler(f, req, **req.url_args)
+                        res = await self._invoke_handler(f, 
+                                req, **req.url_args)
                     if isinstance(res, tuple):
                         res = Response(*res)
                     elif not isinstance(res, Response):
                         res = Response(res)
                     for handler in self.after_request_handlers:
-                        res = await self._invoke_handler(handler, req, res) or res
+                        res = await self._invoke_handler(handler, req, res) \
+                                or res
                 elif 404 in self.error_handlers:
-                    res = await self._invoke_handler(self.error_handlers[404], req)
+                    res = await self._invoke_handler(self.error_handlers[404], 
+                        req)
                 else:
                     res = 'Not found', 404
             except Exception as exc:
@@ -136,8 +139,8 @@ class Microdot(BaseMicrodot):
                         print_exception(exc2)
                 if res is None:
                     if 500 in self.error_handlers:
-                        res = await self._invoke_handler(self.error_handlers[500],
-                                                         req)
+                        res = await self._invoke_handler(
+                            self.error_handlers[500], req)
                     else:
                         res = 'Internal server error', 500
             if isinstance(res, tuple):

--- a/microdot-asyncio/microdot_asyncio.py
+++ b/microdot-asyncio/microdot_asyncio.py
@@ -17,6 +17,8 @@ class Request(BaseRequest):
     async def create(stream, client_addr):
         # request line
         line = (await stream.readline()).strip().decode()
+        if not line:
+            return None
         method, url, http_version = line.split()
         http_version = http_version.split('/', 1)[1]
 
@@ -73,81 +75,84 @@ class Response(BaseResponse):
 
 
 class Microdot(BaseMicrodot):
+    async def serve(self, reader, writer):
+        if not hasattr(writer, 'awrite'):  # pragma: no cover
+            # CPython provides the awrite and aclose methods in 3.8+
+            async def awrite(self, data):
+                self.write(data)
+                await self.drain()
+
+            async def aclose(self):
+                self.close()
+                await self.wait_closed()
+
+            from types import MethodType
+            writer.awrite = MethodType(awrite, writer)
+            writer.aclose = MethodType(aclose, writer)
+        await self.dispatch_request(reader, writer)
+
     def run(self, host='0.0.0.0', port=5000, debug=False):
         self.debug = debug
-
-        async def serve(reader, writer):
-            if not hasattr(writer, 'awrite'):  # pragma: no cover
-                # CPython provides the awrite and aclose methods in 3.8+
-                async def awrite(self, data):
-                    self.write(data)
-                    await self.drain()
-
-                async def aclose(self):
-                    self.close()
-                    await self.wait_closed()
-
-                from types import MethodType
-                writer.awrite = MethodType(awrite, writer)
-                writer.aclose = MethodType(aclose, writer)
-
-            await self.dispatch_request(reader, writer)
 
         if self.debug:  # pragma: no cover
             print('Starting async server on {host}:{port}...'.format(
                 host=host, port=port))
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.start_server(serve, host, port))
+        loop.run_until_complete(asyncio.start_server(self.serve, host, port))
         loop.run_forever()
         loop.close()  # pragma: no cover
 
     async def dispatch_request(self, reader, writer):
         req = await Request.create(reader, writer.get_extra_info('peername'))
-        f = self.find_route(req)
-        try:
-            res = None
-            if f:
-                for handler in self.before_request_handlers:
-                    res = await self._invoke_handler(handler, req)
-                    if res:
-                        break
-                if res is None:
-                    res = await self._invoke_handler(f, req, **req.url_args)
-                if isinstance(res, tuple):
-                    res = Response(*res)
-                elif not isinstance(res, Response):
-                    res = Response(res)
-                for handler in self.after_request_handlers:
-                    res = await self._invoke_handler(handler, req, res) or res
-            elif 404 in self.error_handlers:
-                res = await self._invoke_handler(self.error_handlers[404], req)
-            else:
-                res = 'Not found', 404
-        except Exception as exc:
-            print_exception(exc)
-            res = None
-            if exc.__class__ in self.error_handlers:
-                try:
-                    res = await self._invoke_handler(
-                        self.error_handlers[exc.__class__], req, exc)
-                except Exception as exc2:  # pragma: no cover
-                    print_exception(exc2)
-            if res is None:
-                if 500 in self.error_handlers:
-                    res = await self._invoke_handler(self.error_handlers[500],
-                                                     req)
+        if req:
+            f = self.find_route(req)
+            try:
+                res = None
+                if f:
+                    for handler in self.before_request_handlers:
+                        res = await self._invoke_handler(handler, req)
+                        if res:
+                            break
+                    if res is None:
+                        res = await self._invoke_handler(f, req, **req.url_args)
+                    if isinstance(res, tuple):
+                        res = Response(*res)
+                    elif not isinstance(res, Response):
+                        res = Response(res)
+                    for handler in self.after_request_handlers:
+                        res = await self._invoke_handler(handler, req, res) or res
+                elif 404 in self.error_handlers:
+                    res = await self._invoke_handler(self.error_handlers[404], req)
                 else:
-                    res = 'Internal server error', 500
-        if isinstance(res, tuple):
-            res = Response(*res)
-        elif not isinstance(res, Response):
-            res = Response(res)
-        await res.write(writer)
+                    res = 'Not found', 404
+            except Exception as exc:
+                print_exception(exc)
+                res = None
+                if exc.__class__ in self.error_handlers:
+                    try:
+                        res = await self._invoke_handler(
+                            self.error_handlers[exc.__class__], req, exc)
+                    except Exception as exc2:  # pragma: no cover
+                        print_exception(exc2)
+                if res is None:
+                    if 500 in self.error_handlers:
+                        res = await self._invoke_handler(self.error_handlers[500],
+                                                         req)
+                    else:
+                        res = 'Internal server error', 500
+            if isinstance(res, tuple):
+                res = Response(*res)
+            elif not isinstance(res, Response):
+                res = Response(res)
+            await res.write(writer)
         await writer.aclose()
         if self.debug:  # pragma: no cover
-            print('{method} {path} {status_code}'.format(
-                method=req.method, path=req.path,
-                status_code=res.status_code))
+            if req:
+                print('{method} {path} {status_code}'.format(
+                    method=req.method, path=req.path,
+                    status_code=res.status_code))
+            else:
+                print('(Empty request)')
 
     async def _invoke_handler(self, f_or_coro, *args, **kwargs):
         ret = f_or_coro(*args, **kwargs)


### PR DESCRIPTION
Hi, Miguel!

This patch is similar to #8, but also moved serve() from inside Microdot.run(), making the latter easier to be overridden in a subclass.