### PR TITLE
Move socket import, remove Request.G, and add simple hello example

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,0 +1,26 @@
+from microdot import Microdot, Response
+
+app = Microdot()
+
+htmldoc = """<!DOCTYPE html>
+<html>
+    <head>
+        <title>Microdot Example Page</title>
+    </head>
+    <body>
+        <div>
+            <h1>Microdot Example Page</h1>
+            <p>Hello from Microdot!</p>
+        </div>
+    </body>
+</html>
+"""
+
+
+@app.route("", methods=["GET", "POST"])
+def serial_number(request):
+    print(request.headers)
+    return Response(body=htmldoc, headers={"Content-Type": "text/html"})
+
+
+app.run(debug=True)

--- a/microdot/microdot.py
+++ b/microdot/microdot.py
@@ -43,7 +43,10 @@ except ImportError:
 try:
     import usocket as socket
 except ImportError:
-    import socket
+    try:
+        import socket
+    except ImportError:
+        socket = None
 
 
 def urldecode(string):


### PR DESCRIPTION
Thanks for this neat little library!  I've been using it in some projects with some minor changes which are included in this PR.  They are (see individual commits):
- move `import socket` to `Microdot.run()` so the library can be used on systems that don't have a socket module (eg where the transport is not TCP/IP but rather a serial device like a UART)
- remove unused `Request.G` class (I'm not sure why this is there, maybe it's important?)
- add a simple static-HTML serving app

