### PR TITLE
Copy client headers to avoid write back

### DIFF
--- a/src/microdot.py
+++ b/src/microdot.py
@@ -308,7 +308,7 @@ class Response():
 
     def __init__(self, body='', status_code=200, headers=None):
         self.status_code = status_code
-        self.headers = headers or {}
+        self.headers = headers.copy() if headers else {}
         if isinstance(body, (dict, list)):
             self.body = json.dumps(body).encode()
             self.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
I add a single custom header line, e.g:

```
headers = {'MyCustomHeader': 'custom'}
...
    return Response(body=reply, headers=headers)
```
However, Microdot inadvertently writes `Content-Length` into my client side header dict so the second time that Response gets returned (e.g. with a different length reply) then the new length does not get updated (see [line #355](https://github.com/miguelgrinberg/microdot/blob/dd3fc20507715a23d0fa6fa3aae3715c8fbc0351/src/microdot.py#L355) of `microdot.py`) so the reply is invalid. This PR ensures the library makes a copy of the client headers to avoid this problem.
    