### PR TITLE
Support streaming body content

### DIFF
--- a/tests/microdot/test_request.py
+++ b/tests/microdot/test_request.py
@@ -18,7 +18,7 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(req.cookies, {})
         self.assertEqual(req.content_length, 0)
         self.assertEqual(req.content_type, None)
-        self.assertEqual(req.body, b'')
+        self.assertEqual(req.body, fd)
         self.assertEqual(req.json, None)
         self.assertEqual(req.form, None)
 


### PR DESCRIPTION
A route can specify that the `req.body` should be a streamable object by setting `stream=True` in the route definition:

    @app.route(..., stream=True)
    async def route_handler(req):
        data = await req.body.read()

This allows each route to select whether it wants the default behaviour where the body is read in fully (`req.body` is a bytes object), or if the route will handle the reading itself (`req.body` is the underlying stream object for the incoming request).

I think this is a better approach than setting a simple threshold, above which `req.body` is a stream, because different routes need different behaviour.

I didn't update the tests because there would be a lot of changes.  I can do that if this approach is acceptable.

Addresses issue #26.