### PR TITLE
Remove stray/debug remnant print()

### DIFF
--- a/src/microdot_asyncio.py
+++ b/src/microdot_asyncio.py
@@ -79,7 +79,6 @@ class Request(BaseRequest):
 
         # body
         body = b''
-        print(Request.max_body_length)
         if content_length and content_length <= Request.max_body_length:
             body = await client_stream.readexactly(content_length)
             stream = None


### PR DESCRIPTION
Commit 29a9f6f46c737aa0fd452766c23bd83008594ac4 from a couple of months ago inadvertently included a stray `print()`. This PR removes it.