### PR TITLE
Publish mpy files on Release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,101 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  schedule:
+    - cron: "15 03 * * *"  # Once a day
+  workflow_dispatch:  # Also allow manual trigger
+    inputs:
+      mpy_cross_versions:  # A json list of mpy-cross versions to generate releases for
+        required: true
+
+jobs:
+  matrix-prep-mpy-cross-version:
+    runs-on: ubuntu-latest
+    steps:
+      - id: get-latest-mpy-cross-versions
+        # If this was triggered by newly pushed tag we want to return the latest 5 versions of micropython
+        # If this was triggered manually we wan to use the input value
+        # If this was triggered by schedule we want to return only the latest version of micropython
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]
+          then
+            mpy_cross_versions=$(curl -Ls https://pypi.org/pypi/mpy-cross/json | jq  -r '.releases | keys | .[]' | sort -V | jq -c --raw-input --slurp 'split("\n") | .[-6:-1]')
+            echo "MPY_CROSS_VERSIONS=$mpy_cross_versions" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]
+          then
+            echo 'MPY_CROSS_VERSIONS=${{ github.event.inputs.mpy_cross_versions }}' >> "$GITHUB_OUTPUT"
+          else
+            mpy_cross_versions=$(curl -Ls https://pypi.org/pypi/mpy-cross/json | jq  -r '.releases | keys | .[]' | sort -V | jq -c --raw-input --slurp 'split("\n") | .[-2:-1]')
+            echo "MPY_CROSS_VERSIONS=$mpy_cross_versions" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      # Will look like '["1.17","1.18","1.19","1.19.1","1.20.0"]'
+      mpy_cross_versions: ${{ steps.get-latest-mpy-cross-versions.outputs.MPY_CROSS_VERSIONS  }}
+  martix-prep-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # If this was triggered by newly pushed tag we want to return only that tag
+      # Otherwise we want to return all tags
+      - id: get-tags
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]
+          then
+            echo "TAGS=[\"${{ github.ref_name }}\"]" >> "$GITHUB_OUTPUT"
+          else
+            git fetch --tags
+            tags=$(git tag -l v*.*.* | jq -c --raw-input --slurp 'split("\n") | .[:-1]')
+            echo "TAGS=$tags" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+        # Will look like '["v1.3.3"]'
+        tags: ${{ steps.get-tags.outputs.TAGS }}
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs:
+      - matrix-prep-mpy-cross-version
+      - martix-prep-tags
+    strategy:
+      max-parallel: 5  # Only run 5 jobs at once so we don't get rate limited
+      matrix:
+        version: ${{ fromJSON(needs.matrix-prep-mpy-cross-version.outputs.mpy_cross_versions) }}
+        tag: ${{ fromJSON(needs.martix-prep-tags.outputs.tags) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.tag }}
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependancies
+        id: install-deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install mpy-cross==${{ matrix.version }}
+
+      - name: Build
+        run: |
+          mkdir build
+          for f in $(find src/ -type f -name "*.py"); do mpy-cross -o build/$(basename $f .py).mpy $f; done
+
+      - name: Get commit SHA
+        id: get-commit-sha
+        run: |
+          tag_sha=$(git rev-list -n 1 ${{ matrix.tag }})
+          echo "TAG_SHA=$tag_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: "Release ${{ matrix.tag }} for micropython-${{ matrix.version }}"
+          tag: "micropython-${{ matrix.version }}-${{ matrix.tag }}"
+          commit: ${{ steps.get-commit-sha.outputs.TAG_SHA }}
+          artifacts: "build/*.mpy"
+          skipIfReleaseExists: true

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -16,6 +16,11 @@ them to *.mpy* files. These source files can also be
 `frozen <https://docs.micropython.org/en/latest/develop/optimizations.html?highlight=frozen#frozen-bytecode>`_
 and incorporated into a custom MicroPython firmware.
 
+Alternatively you can install using `mpremote` and `mip`
+```
+mpremote a0 mip install https://github.com/miguelgrinberg/microdot/releases/download/micropython-1.20-v1.3.3/microdot.mpy
+```
+
 Getting Started
 ---------------
 


### PR DESCRIPTION
This PR will automatically compile `mpy` files for any `.py` files in `src/` 

The workflow has 3 modes:

1. When a new tag is created matching (`v*.*.*`), python source files in `src/` will be complied for the latest 5 versions of micropython/mpy-cross and a release created for each version of micropython/mpy-cross with the compiled mpy files attached as assets.

Example workflow:

https://github.com/markafarrell/microdot/actions/runs/6211289626

3. Once daily a workflow will run that will iterate over all tags matching `v*.*.*`, python source files in `src/` will be complied for the latest version of micropython/mpy-cross and a release created with the compiled mpy files attached as assets. This will mean that when new version of mpy-cross are released there will also be compiled version of microdot available for people to use.

Example workflow:

https://github.com/markafarrell/microdot/actions/runs/6211317787

3. The workflow can also be run manually and a json list of mpy-cross versions provided as an input. e.g. `["1.19.0", "1.19.1"]`. This will result in releases being created for all tags matching `v*.*.*` compiled for the supplied versions of micropython. This will allow for the ad-hoc creation of compiled versions of microdot for any available version of micro-python.     

Example workflow:

https://github.com/markafarrell/microdot/actions/runs/6211299190

This will make it easier for consumers to be able to consume microdot using `mip`

e.g. 

```
mpremote a0 mip install https://github.com/miguelgrinberg/microdot/releases/download/micropython-1.20-v1.3.3/microdot.mpy
```