### PR TITLE
Remove unnecessary async in sub application creation in docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -462,7 +462,7 @@ the sub-applications to build the larger combined application::
     from customers import customers_app
     from orders import orders_app
 
-    async def create_app():
+    def create_app():
         app = Microdot()
         app.mount(customers_app, url_prefix='/customers')
         app.mount(orders_app, url_prefix='/orders')


### PR DESCRIPTION
If you use `async`, it gives you the error:

```
Traceback (most recent call last):
  File "<stdin>", line 31, in <module>
AttributeError: 'generator' object has no attribute 'run'
```

Without it, it runs as expected. I'm not an expert in python, but it feels like it's not necessary for the application creation since the function is synchronous.
