### PR TITLE
Update sse.py

### DIFF
--- a/src/microdot/sse.py
+++ b/src/microdot/sse.py
@@ -12,13 +12,15 @@ class SSE:
         self.event = asyncio.Event()
         self.queue = []
 
-    async def send(self, data, event=None):
+    async def send(self, data, event=None, event_id=None):
         """Send an event to the client.
 
         :param data: the data to send. It can be given as a string, bytes, dict
                      or list. Dictionaries and lists are serialized to JSON.
                      Any other types are converted to string before sending.
         :param event: an optional event name, to send along with the data. If
+                      given, it must be a string.
+        :param event_id: an optional event id, to send along with the data. If
                       given, it must be a string.
         """
         if isinstance(data, (dict, list)):
@@ -28,6 +30,8 @@ class SSE:
         elif not isinstance(data, bytes):
             data = str(data).encode()
         data = b'data: ' + data + b'\n\n'
+        if event_id:
+            data = b'id: ' + event_id.encode() + b'\n' + data
         if event:
             data = b'event: ' + event.encode() + b'\n' + data
         self.queue.append(data)

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -23,6 +23,8 @@ class TestWebSocket(unittest.TestCase):
         async def handle_sse(request, sse):
             await sse.send('foo')
             await sse.send('bar', event='test')
+            await sse.send('bar', event='test', event_id='id42')
+            await sse.send('bar', event_id='id42')
             await sse.send({'foo': 'bar'})
             await sse.send([42, 'foo', 'bar'])
             await sse.send(ValueError('foo'))
@@ -34,6 +36,8 @@ class TestWebSocket(unittest.TestCase):
         self.assertEqual(response.headers['Content-Type'], 'text/event-stream')
         self.assertEqual(response.text, ('data: foo\n\n'
                                          'event: test\ndata: bar\n\n'
+                                         'event: test\nid: id42\ndata: bar\n\n'
+                                         'id: id42\ndata: bar\n\n'
                                          'data: {"foo": "bar"}\n\n'
                                          'data: [42, "foo", "bar"]\n\n'
                                          'data: foo\n\n'


### PR DESCRIPTION
Add optional `event_id` parameter to `SSE.send()` method.

For use cases where the client resets the EventSource connection, so that the client state can be gracefully restored in sync with the server.  It should also make handling event streams from multiple clients easier.

The server request handler can check the "Last-Event-ID" value (if present) in the request header which should be set automatically when a client EventSource reconnects, and then set a starting point for resuming the data stream on that endpoint.  For example:

```py
@app.route("/status")
@with_sse
async def status_handler(request, sse):
    last_event_id = request.headers.get("Last-Event-ID", "")
    ...

```