### PR TITLE
add js to sse example

### DIFF
--- a/examples/sse/counter.py
+++ b/examples/sse/counter.py
@@ -1,5 +1,5 @@
 import asyncio
-from microdot import Microdot
+from microdot import Microdot, send_file
 from microdot.sse import with_sse
 
 app = Microdot()
@@ -7,47 +7,22 @@ app = Microdot()
 
 @app.route("/")
 async def main(request):
-    html = """
-    <!DOCTYPE html>
-    <html>
-        <head>
-            <title>Microdot SSE Example</title>
-            <meta charset="UTF-8">
-        </head>
-        <body>
-            <h1>Microdot SSE Example</h1>
-            <script>
-            // Create a new EventSource instance with the endpoint URL
-            const eventSource = new EventSource('/events');
-
-            // Listen for incoming messages
-            eventSource.onmessage = (event) => {
-                console.log('Received message:', event.data);
-            };
-
-            // Handle connection errors
-            eventSource.onerror = (error) => {
-                console.error('EventSource failed:', error);
-            };
-
-            // Optionally handle connection opening
-            eventSource.onopen = () => {
-                console.log('Connection to server opened.');
-            };
-            </script>
-        </body>
-    </html>
-    """
-    return html, 200, {'Content-Type': 'text/html'}
+    return send_file('index.html')
 
 
 @app.route('/events')
 @with_sse
 async def events(request, sse):
-    i = 0
-    while True:
-        await asyncio.sleep(1)
-        i += 1
-        await sse.send({'counter': i})
+    print('Client connected')
+    try:
+        i = 0
+        while True:
+            await asyncio.sleep(1)
+            i += 1
+            await sse.send({'counter': i})
+    except asyncio.CancelledError:
+        pass
+    print('Client disconnected')
 
-app.run(debug=True)
+
+app.run()

--- a/examples/sse/counter.py
+++ b/examples/sse/counter.py
@@ -5,12 +5,49 @@ from microdot.sse import with_sse
 app = Microdot()
 
 
+@app.route("/")
+async def main(request):
+    html = """
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <title>Microdot SSE Example</title>
+            <meta charset="UTF-8">
+        </head>
+        <body>
+            <h1>Microdot SSE Example</h1>
+            <script>
+            // Create a new EventSource instance with the endpoint URL
+            const eventSource = new EventSource('/events');
+
+            // Listen for incoming messages
+            eventSource.onmessage = (event) => {
+                console.log('Received message:', event.data);
+            };
+
+            // Handle connection errors
+            eventSource.onerror = (error) => {
+                console.error('EventSource failed:', error);
+            };
+
+            // Optionally handle connection opening
+            eventSource.onopen = () => {
+                console.log('Connection to server opened.');
+            };
+            </script>
+        </body>
+    </html>
+    """
+    return html, 200, {'Content-Type': 'text/html'}
+
+
 @app.route('/events')
 @with_sse
 async def events(request, sse):
-    for i in range(10):
+    i = 0
+    while True:
         await asyncio.sleep(1)
+        i += 1
         await sse.send({'counter': i})
 
-
-app.run(debug=True)
+app.run()

--- a/examples/sse/counter.py
+++ b/examples/sse/counter.py
@@ -50,4 +50,4 @@ async def events(request, sse):
         i += 1
         await sse.send({'counter': i})
 
-app.run()
+app.run(debug=True)

--- a/examples/sse/index.html
+++ b/examples/sse/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Microdot SSE Example</title>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <h1>Microdot SSE Example</h1>
+    <div id="log"></div>
+    <script>
+      const log = (text, color) => {
+        document.getElementById('log').innerHTML += `<span style="color: ${color}">${text}</span><br>`;
+      };
+
+      const eventSource = new EventSource('/events');
+
+      eventSource.onopen = () => {
+        log('Connection to server opened.', 'black');
+      };
+
+      eventSource.onmessage = (event) => {
+        log(`Received message: ${event.data}`, 'blue');
+      };
+
+      eventSource.onerror = (event) => {
+        log(`EventSource failed: ${event.type}`, 'red');
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This adds some JavaScript examples to the SSE documentation, so the log output is being streamed correctly in Safari. Before it would just show the finished result on Safari, now the progress can be seen in the console.
closes #280 