### PR TITLE
Fix WebSocket._read_frame() to handle partial reads from socket.read()

### DIFF
--- a/src/microdot/websocket.py
+++ b/src/microdot/websocket.py
@@ -160,7 +160,12 @@ class WebSocket:
             raise WebSocketError('Message too large')
         if has_mask:  # pragma: no cover
             mask = await self.request.sock[0].read(4)
-        payload = await self.request.sock[0].read(length)
+        payload = bytearray()
+        while len(payload) < length:
+            chunk = await self.request.sock[0].read(length - len(payload))
+            if not chunk:
+                raise WebSocketError("Unexpected end of stream") # pragma: no cover
+            payload.extend(chunk)
         if has_mask:  # pragma: no cover
             payload = bytes(x ^ mask[i % 4] for i, x in enumerate(payload))
         return opcode, payload


### PR DESCRIPTION
MicroPython socket.read() may return fewer bytes than requested when reading from non-blocking sockets. 

See: https://docs.micropython.org/en/latest/library/socket.html#socket.socket.read

The solution is to keep reading from the socket until the required amount of bytes was read. 

Partial reads are unlikely to occur when reading small amounts of bytes from the socket. However, when sending large payloads, such as chunks of files, they become very common. My problem in #294 was actually caused by this. It appears that the partial reads eventually resulted in the data being misinterpreted as a continuation frame header.