### PR TITLE
Handle missing Content-Type in multipart parser

### DIFF
--- a/src/microdot/multipart.py
+++ b/src/microdot/multipart.py
@@ -42,7 +42,7 @@ class FormDataIter:
         self.buffer = None
         try:
             mimetype, boundary = request.content_type.rsplit('; boundary=', 1)
-        except ValueError:
+        except (AttributeError, ValueError):
             return  # not a multipart request
         if mimetype.split(';', 1)[0] == \
                 'multipart/form-data':  # pragma: no branch

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -172,6 +172,20 @@ class TestMultipart(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.text, 'None')
 
+    def test_no_content_type(self):
+        app = Microdot()
+
+        @app.route('/upload', methods=['GET', 'POST'])
+        @with_form_data
+        async def async_route(req):
+            return str(req.form)
+
+        client = TestClient(app)
+
+        res = self._run(client.get('/upload'))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.text, 'None')
+
     def test_upload_iterator(self):
         app = Microdot()
 


### PR DESCRIPTION
Fixes #364.

`FormDataIter.__init__` calls `request.content_type.rsplit('; boundary=', 1)`, which assumes `content_type` is a string. For a request with no body (e.g. a GET on a route decorated with `with_form_data`, as in the linked issue), `content_type` is `None` and this raises an unhandled `AttributeError`, returning a 500.

This catches `AttributeError` alongside the existing `ValueError` so such requests are treated as having no form data, matching the documented behavior.

Added a regression test (`test_no_content_type`) that issues a GET to a `with_form_data` route; it fails (500) before the change and passes after.